### PR TITLE
Fix bug with alt text containing "null"

### DIFF
--- a/read-alt-text.js
+++ b/read-alt-text.js
@@ -20,8 +20,9 @@ module.exports = (tw, original_user) => {
     }
   }
 
+  // Twitter returns the string "null" when alt text is not present
   if (alt === "null") {
-   alt = "There is no alt text for this image, I'm sorry." 
+    alt = "There is no alt text for this image, I'm sorry." 
   }
   
   return alt;

--- a/read-alt-text.js
+++ b/read-alt-text.js
@@ -20,5 +20,9 @@ module.exports = (tw, original_user) => {
     }
   }
 
-  return alt.replace(/null/g, "There is no alt text for this image, I'm sorry.")
+  if (alt === "null") {
+   alt = "There is no alt text for this image, I'm sorry." 
+  }
+  
+  return alt;
 }


### PR DESCRIPTION
Fixing bug where alt text that has the word "null" in it shows correctly except for the part that has the word "null", e.g. https://twitter.com/get_altText/status/1408469519908184071

Checks for the explicit string "null" instead of doing a global replace, since Twitter returns the word "null" when there's no alt text.